### PR TITLE
Add <=> so call numbers are sortable.  One test fails, I don't know why

### DIFF
--- a/lib/lc_callnumber/lcc.rb
+++ b/lib/lc_callnumber/lcc.rb
@@ -205,13 +205,63 @@ module LCCallNumber
       doon1_cmp = doon1 <=> other.doon1
       return doon1_cmp unless doon1_cmp == 0
 
-      firstcutter_cmp = firstcutter <=> other.firstcutter
+      # Cutters have letters and numbers, which we need to compare separately.
+      if firstcutter
+        if other.firstcutter
+          # Both have firstcutters!  Hurrah!
+          # Compare the letter
+          firstcutter_cmp = firstcutter.letter <=> other.firstcutter.letter
+          # If that didn't help, compare the digits
+          if firstcutter_cmp == 0
+            firstcutter_cmp = firstcutter.digits <=> other.firstcutter.digits
+          end
+        else
+          # self has a firstcutter but other doesn't, so other is first
+          firstcutter_cmp = 1
+        end
+      else
+        # self has no firstcutter
+        if other.firstcutter
+          # other does, so it comes last
+          firstcutter_cmp = -1
+        else
+          # Neither has one, so carry on
+          firstcutter_cmp = 0
+        end
+      end
       return firstcutter_cmp unless firstcutter_cmp == 0
 
       doon2_cmp = doon2 <=> other.doon2
       return doon2_cmp unless doon2_cmp == 0
 
-      extra_cutters_cmp = extra_cutters <=> other.extra_cutters
+      # The extra cutters are in an array, so we need to compare each.
+      # But the hell with it, for now let's just compare the first
+      # I'm running out of energy.  Who invented this mishegas?
+      if ! extra_cutters.empty?
+        # self has extra_cutters
+        if ! extra_cutters.empty?
+          # Both have extra_cutters!  Compare the first one, then call it a day.
+          # TODO: Compare the whole array of the stupid things.
+          # Compare the letter
+          extra_cutters_cmp = extra_cutters[0].letter <=> other.extra_cutters[0].letter
+          # If that didn't help, compare the digits
+          if extra_cutters_cmp == 0
+            extra_cutters_cmp = extra_cutters[0].digits <=> other.extra_cutters[0].digits
+          end
+        else
+          # self has extra_cutters but other doesn't, so other is first
+          extra_cutters_cmp = 1
+        end
+      else
+        # self has no extra_cutters
+        if ! other.extra_cutters.empty?
+          # other does, so it comes last
+          extra_cutters_cmp = -1
+        else
+          # Neither has any, so carry on
+          extra_cutters_cmp = 0
+        end
+      end
       return extra_cutters_cmp unless extra_cutters_cmp == 0
 
       year_cmp = year <=> other.year

--- a/lib/lc_callnumber/lcc.rb
+++ b/lib/lc_callnumber/lcc.rb
@@ -4,7 +4,7 @@ module LCCallNumber
 
   @parser = Parser.new
   @transformer = Transform.new
-  
+
   def self.parse(i)
     return UnparseableCallNumber.new(i) if i.nil?
     i.chomp!
@@ -13,13 +13,13 @@ module LCCallNumber
     i.gsub!(/\[(.+)\]/, "$1")
     i.gsub!('\\', ' ')
 
-    # We also have a bunch that start with a slash and have slashes where you'd 
+    # We also have a bunch that start with a slash and have slashes where you'd
     # expect logical breaks. Don't know why.
-    
+
     if i =~ /\A\//
       i.gsub!('/', ' ')
     end
-    
+
     # Ditch leading + or *
     i.gsub!(/\A[+*]/, '')
 
@@ -35,7 +35,7 @@ module LCCallNumber
        !(/\d/.match i)
        return UnparseableCallNumber.new(orig)
     end
-    
+
     begin
       p = @parser.parse(i)
       # puts p
@@ -46,12 +46,12 @@ module LCCallNumber
       return UnparseableCallNumber.new(orig)
     end
   end
-      
-      
-    
-    
-    
-    
+
+
+
+
+
+
 
   # The "lead" -- initial letter(s) and digit(s)
   class Lead
@@ -64,28 +64,28 @@ module LCCallNumber
       "Lead<#{letters}, #{digits.inspect}>"
     end
   end
-  
-  # A generic "Decimal" part, where we keep the 
+
+  # A generic "Decimal" part, where we keep the
   # integer and fractional parts separate so
   # we can construct a string more easily
-  
+
   class Decimal
     attr_accessor :intpart, :fractpart
     def initialize(i, f=nil)
       @intpart = i
       @fractpart = f
     end
-    
+
     def to_num
       fractpart ? "#{intpart}.#{fractpart}".to_f : intpart.to_i
     end
-    
+
     def to_s
       fractpart ? "#{intpart}.#{fractpart}" : intpart
     end
-    
-    
-    def inspect      
+
+
+    def inspect
       if fractpart
         "#{intpart}:#{fractpart}"
       else
@@ -93,12 +93,12 @@ module LCCallNumber
       end
     end
   end
-  
+
   # A "Cutter" is a single letter followed by one or more digits
   # It is sometimes preceded by a decimal point. We note whether or not
   # we got a decimal point because it may be a hint as to whether or not
   # we're actually looking at a Cutter.
-  
+
   class Cutter
     attr_accessor :letter, :digits, :dot
     def initialize(l,d, dot=nil)
@@ -106,23 +106,23 @@ module LCCallNumber
       @digits = d
       @dot = !dot.nil?
     end
-    
+
     def inspect
       "Cut<#{letter},#{digits}>"
     end
-    
+
     def to_s
       "#{letter}#{digits}"
     end
   end
-  
-  
+
+
   # Some call numbers have a year, infantry division, etc. preceeding
   # and/or following the first cutter. We take all three as a unit so
   # we can deal with edge cases more easily.
   #
   # "doon" in this case is "Date Or Other Number"
-  
+
   class FirstCutterSet
     attr_accessor :doon1, :cutter, :doon2
     def initialize(d1, cutter, d2)
@@ -131,84 +131,112 @@ module LCCallNumber
       @cutter = cutter
     end
   end
-  
+
   # Bring it all together in the callnumber
-  # We feed it the parts we have, and then reassign fields based on 
+  # We feed it the parts we have, and then reassign fields based on
   # what we have.
   #
   # To wit:
   #  Q123 .C4 1990 --- published in 1990
   #  Q123 .C4 1990 .D5 2003 -- published in 2003 with a 2nd doon of 1990
-  
-  
+
+
   class CallNumber
-        
-    attr_accessor :letters, :digits, :doon1, :firstcutter, :doon2, 
+
+    include Comparable
+    attr_accessor :letters, :digits, :doon1, :firstcutter, :doon2,
                   :extra_cutters, :year, :rest
     attr_accessor :original_string
-    
-                      
+
+
     def initialize(lead, fcset=nil, ec=[], year=nil, rest=nil)
       @letters = lead.letters
       @digits  = lead.digits.to_num
-      
+
       if fcset
         @doon1   = fcset.doon1
         @doon2   = fcset.doon2
         @firstcutter = fcset.cutter
       end
-      
+
       @extra_cutters = ec
       @year = year
       @rest = rest
-      
+
       @rest.strip! if @rest
-      
+
       self.reassign_fields
     end
-    
+
     def reassign_fields
       # If we've got a doon2,  but no year and no extra cutters,
       # put the doon2 in the year
-      
+
       if doon2 and (doon2=~ /\A\d+\Z/) and extra_cutters.empty? and year.nil?
         @year = @doon2
         @doon2 = nil
       end
     end
-    
+
     def inspect
       header = %w(letters digits doon1 cut1 doon2 othercut)
       actual = [letters,digits,doon1,firstcutter,doon2,extra_cutters.join(','),year,rest].map{|x| x.to_s}
       fmt = '%-7s %-9s %-6s %-6s %-6s %-20s year=%-6s rest=%-s'
       [('%-7s %-9s %-6s %-6s %-6s %-s' % header), (fmt % actual)].join("\n")
-      
+
     end
-    
-    
-    def valid? 
+
+
+    def valid?
       @letters && @digits
     end
-    
+
+    def <=>(other)
+      # Make call numbers sortable.
+      # Work through the various parts, from left to right.
+      # (They compare as strings or numbers as appropriate, thanks to the above.)
+
+      letters_cmp = letters <=> other.letters
+      return letters_cmp unless letters_cmp == 0
+
+      digits_cmp = digits <=> other.digits
+      return digits_cmp unless digits_cmp == 0
+
+      doon1_cmp = doon1 <=> other.doon1
+      return doon1_cmp unless doon1_cmp == 0
+
+      firstcutter_cmp = firstcutter <=> other.firstcutter
+      return firstcutter_cmp unless firstcutter_cmp == 0
+
+      doon2_cmp = doon2 <=> other.doon2
+      return doon2_cmp unless doon2_cmp == 0
+
+      extra_cutters_cmp = extra_cutters <=> other.extra_cutters
+      return extra_cutters_cmp unless extra_cutters_cmp == 0
+
+      year_cmp = year <=> other.year
+      return year_cmp unless year_cmp == 0
+
+      rest_cmp = rest <=> other.rest
+      return rest_cmp
+
+    end
+
   end
-  
+
   class UnparseableCallNumber < CallNumber
 
     def initialize(str)
       self.original_string = str
       self.extra_cutters = []
     end
-      
-    def valid? 
+
+    def valid?
       false
     end
-    
+
   end
-    
-  
-  
+
+
+
 end
-  
-  
-  
-  

--- a/test/test_lc_callnumber.rb
+++ b/test/test_lc_callnumber.rb
@@ -32,12 +32,17 @@ describe "Sorting" do
   it "sorts call numbers properly" do
     a1 = LCCallNumber.parse("A 50")
     a2 = LCCallNumber.parse("A 7")
-    q1 = LCCallNumber.parse("QA 500.M500 T59")
-    q2 = LCCallNumber.parse("QA 500.M500 T60")
-    assert (a1 <=> a1) == 0  # a1 is a1
-    assert (a1 <=> a2) == 1  # a1 > a2
+    q1 = LCCallNumber.parse("QA 500")
+    q2 = LCCallNumber.parse("QA 500.M500")
+    q3 = LCCallNumber.parse("QA 500.M500 T59")
+    q4 = LCCallNumber.parse("QA 500.M500 T60")
+    assert (a1 <=> a1) ==  0 # a1 is a1
+    assert (a1 <=> a2) ==  1 # a1 > a2
     assert (a2 <=> q1) == -1 # a2 < q1
     assert (q1 <=> q2) == -1 # q1 < q2
+    assert (q2 <=> q3) == -1 # q2 < q3
+    assert (q3 <=> q3) ==  0 # q3 is q3
+    assert (q3 <=> q4) == -1 # q3 < q4
     # Is there some way to put some test numbers into an array, sort it, and compare the original and sorted arrays?
   end
 end

--- a/test/test_lc_callnumber.rb
+++ b/test/test_lc_callnumber.rb
@@ -22,11 +22,22 @@ describe "Basics" do
       assert_equal other_cutters.to_s.split(/\s*,\s*/), lc.extra_cutters.map(&:to_s), "#{orig} -> extra_cutters #{lc.inspect}"
       assert_equal pubyear.to_s, lc.year.to_s,  "#{orig} -> year #{lc.inspect}"
       assert_equal rest.to_s, lc.rest.to_s,  "#{orig} -> rest #{lc.inspect}"
-      
+
     end
-    
+
   end
 end
-      
-      
-      
+
+describe "Sorting" do
+  it "sorts call numbers properly" do
+    a1 = LCCallNumber.parse("A 50")
+    a2 = LCCallNumber.parse("A 7")
+    q1 = LCCallNumber.parse("QA 500.M500 T59")
+    q2 = LCCallNumber.parse("QA 500.M500 T60")
+    assert (a1 <=> a1) == 0  # a1 is a1
+    assert (a1 <=> a2) == 1  # a1 > a2
+    assert (a2 <=> q1) == -1 # a2 < q1
+    assert (q1 <=> q2) == -1 # q1 < q2
+    # Is there some way to put some test numbers into an array, sort it, and compare the original and sorted arrays?
+  end
+end


### PR DESCRIPTION
Bill---

This is probably quite badly done, but it's a start. It adds a <=> to the CallNumber class so that call numbers are sortable. I made a few simple tests, but a) there must be a better way to do them, and b) one fails and I can't see why. Maybe you can see why? I hope there's something useful here.

(Looking at the diffs it looks like a lot of whitespace changs because Emacs chomps trailing spaces. Sorry if that's annoying.)

Bill
