### PR TITLE
Cutter sorting bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Includes simple getters/setters and a PEG parser.
 ## Things that aren't yet done
 
 * Normalization: create a string that can be compared with other normalized strings to correctly order the call numbers
-* Implement `<=>` so call number object can be compared.
 * Much better testing
 
 
@@ -30,20 +29,21 @@ The OCLC has [a page explaining how LC Call Numbers are composed](http://www.ocl
 
 For purposes of this class, an LC Call Number consists of the following parts. Only the first two are required; everything else is optional.
 
-* __Letter(s).__ One or more letters
-* __Digit(s).__ One or more digits, optionally with a decimal point. 
-* __Doon1 (_Date Or Other Number_)__. [Note: no one but me calls it a 'doon', but I needed a term and there wasn't another]. Relatively rare as these things go, a DOON is used to represent the date the work is _about_ (as opposed to, say, the year it was published) or, in some cases, an identifier for an army division or group (say, "12th" for the US Army Twelfth Infantry). 
-* __First cutter__. The first "Cutter Number" consisting of a letter followed by one or more digits. The first cutter is always supposed to be preceded by a dot, but, you know, isn't always.
-* __Doon2__. Another date or other number
-* __"Extra" Cutters__. The 2nd through Nth Cutter numbers, lumped together because we don't have to worry about them getting interspersed with doons.
-* __Year__. The year of publication
-* __"Rest"__. Everything and anything else. 
+* __Letter(s).__ One or more letters.
+* __Digit(s).__ One or more digits, optionally with a decimal point.
+* __Doon1 (_Date Or Other Number_)__. [Note: no one but me calls it a 'doon', but I needed a term and there wasn't another]. Relatively rare as these things go, a DOON is used to represent the date the work is _about_ (as opposed to, say, the year it was published) or, in some cases, an identifier for an army division or group (say, "12th" for the US Army Twelfth Infantry).
+* __First Cutter__. The first "Cutter number," consisting of a letter followed by one or more digits. The first Cutter is always supposed to be preceded by a dot, but, you know, isn't always.
+* __Doon2__. Another date or other number.
+* __"Extra" Cutters__. The 2nd through nth Cutter numbers, lumped together because we don't have to worry about them getting interspersed with doons.
+* __Year__. The year of publication.
+* __"Rest"__. Everything and anything else.
+
 
 ## Usage
 
 In general, you won't be building these things up by hand; you'll try to parse them.
 
-Note that in the case below, while in theory this could be a callnumber with a single cutter followed by a doon2 and no year, we presume the '1990' is a year and don't call it a doon.
+Note that in the case below, while in theory this could be a callnumber with a single Cutter followed by a doon2 and no year, we presume the '1990' is a year and don't call it a doon.
 
 ~~~ruby
 
@@ -60,6 +60,10 @@ lc.rest      #=> nil
 
 lc = LCCallNumber.parse('A .B3') #=> LCCallNumber::UnparseableCallNumber
 lc.valid? #=> false
+
+a = LCCallNumber.parse("B 528.S43")
+b = LCCallNumber.parse("B 528.S298")
+a <=> b # -1
 
 ~~~
 
@@ -79,13 +83,10 @@ Or install it yourself as:
     $ gem install lc_callnumber
 
 
-
-
-
 ## Contributing
 
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+5. Create new pull request

--- a/lib/lc_callnumber/lcc.rb
+++ b/lib/lc_callnumber/lcc.rb
@@ -213,7 +213,8 @@ module LCCallNumber
           firstcutter_cmp = firstcutter.letter <=> other.firstcutter.letter
           # If that didn't help, compare the digits
           if firstcutter_cmp == 0
-            firstcutter_cmp = firstcutter.digits <=> other.firstcutter.digits
+            # Compare numbers as strings, because S43 < S298
+            firstcutter_cmp = firstcutter.digits.to_s <=> other.firstcutter.digits.to_s
           end
           # If that didn't help, if other has an extra_cutter, it is last
           if firstcutter_cmp == 0
@@ -249,7 +250,8 @@ module LCCallNumber
             extra_cutters_cmp = extra_cutters[i].letter <=> other.extra_cutters[i].letter
             # If that didn't help, compare the digits
             if extra_cutters_cmp == 0
-              extra_cutters_cmp = extra_cutters[i].digits <=> other.extra_cutters[i].digits
+              # Compare numbers as strings, because S43 < S298
+              extra_cutters_cmp = extra_cutters[i].digits.to_s <=> other.extra_cutters[i].digits.to_s
             end
             # If that didn't help, if self has no more extra_cutters but other does, self is first
             if extra_cutters_cmp == 0

--- a/test/test_lc_callnumber.rb
+++ b/test/test_lc_callnumber.rb
@@ -29,24 +29,41 @@ describe "Basics" do
 end
 
 describe "Sorting" do
-  it "sorts call numbers properly" do
-    a1 = LCCallNumber.parse("A 50")
-    a2 = LCCallNumber.parse("A 7")
-    q1 = LCCallNumber.parse("QA 500")
-    q2 = LCCallNumber.parse("QA 500.M500")
-    q3 = LCCallNumber.parse("QA 500.M500 T59")
-    q4 = LCCallNumber.parse("QA 500.M500 T60")
-    q5 = LCCallNumber.parse("QA 500.M500 T60 A1")
-    q6 = LCCallNumber.parse("QA 500.M500 T60 Z54")
-    assert (a1 <=> a1) ==  0 # a1 is a1
-    assert (a1 <=> a2) ==  1 # a1 > a2
-    assert (a2 <=> q1) == -1 # a2 < q1
-    assert (q1 <=> q2) == -1 # q1 < q2
-    assert (q2 <=> q3) == -1 # q2 < q3
-    assert (q3 <=> q3) ==  0 # q3 is q3
-    assert (q3 <=> q4) == -1 # q3 < q4
-    assert (q4 <=> q5) == -1 # q4 < q5
-    assert (q5 <=> q6) == -1 # q5 < q6
-    # Is there some way to put some test numbers into an array, sort it, and compare the original and sorted arrays?
+  a1 = LCCallNumber.parse("A 50")
+  a2 = LCCallNumber.parse("A 7")
+  b1 = LCCallNumber.parse("B 528.S43")
+  b2 = LCCallNumber.parse("B 528.S298")
+  q1 = LCCallNumber.parse("QA 500")
+  q2 = LCCallNumber.parse("QA 500.M500")
+  q3 = LCCallNumber.parse("QA 500.M500 T59")
+  q4 = LCCallNumber.parse("QA 500.M500 T60")
+  q5 = LCCallNumber.parse("QA 500.M500 T60 A1")
+  q6 = LCCallNumber.parse("QA 500.M500 T60 Z54")
+  it "knows call numbers equal themselves" do
+    assert (a1 <=> a1) ==  0 # A == A (very Aristotelian)
+  end
+  it "sorts first letters properly" do
+    assert (a2 <=> q1) == -1 # A < Q
+  end
+  it "sorts first digits properly" do
+    assert (a1 <=> a2) ==  1 # A 50 > A 7
+  end
+  it "sorts when one item has no Cutter" do
+    assert (q1 <=> q2) == -1 # QA 500 < QA 500.M500
+  end
+  it "sorts first Cutters properly" do
+    assert (b1 <=> b2) ==  1 # S43 > S298
+  end
+  it "sorts when one item has a Cutter, one an extra Cutter" do
+    assert (q2 <=> q3) == -1 # M500 < M500 T59
+  end
+  it "sorts properly on second Cutters" do
+    assert (q3 <=> q4) == -1 # T59 < T60
+  end
+  it "sorts when one item has two Cutters, one has three" do
+    assert (q4 <=> q5) == -1 # M500 T60 < M500 T60 A1
+  end
+  it "sorts properly on third Cutters" do
+    assert (q5 <=> q6) == -1 # A1 < Z54
   end
 end


### PR DESCRIPTION
The numbers in Cutter numbers have to be sorted as strings, not numbers, because S43 > S299 (because S43 is like S430.
